### PR TITLE
Add GCS Metadata Support For Contentful Exports

### DIFF
--- a/cmd/dumpb/bigquery.go
+++ b/cmd/dumpb/bigquery.go
@@ -22,7 +22,7 @@ var (
 var bigQueryCmd = &cobra.Command{
 	Use:   "bigquery",
 	Short: "Dumps contents of bigquery via ",
-	RunE: exportWrapper("BigQuery", func(ctx context.Context, l *slog.Logger, storage storageWriter) (string, error) {
+	RunE: exportWrapper("BigQuery", func(ctx context.Context, l *slog.Logger, sw storageWriter) (string, error) {
 		storage, err := configuredStorage(ctx)
 		if err != nil {
 			return "", err

--- a/cmd/dumpb/bitbucket.go
+++ b/cmd/dumpb/bitbucket.go
@@ -21,7 +21,7 @@ var (
 var bitbucketCmd = &cobra.Command{
 	Use:   "bitbucket",
 	Short: "Dumps bitbucket accounts in a destination bucket",
-	RunE: exportWrapper("BitBucket", func(ctx context.Context, l *slog.Logger, storage storageWriter) (string, error) {
+	RunE: exportWrapper("BitBucket", func(ctx context.Context, l *slog.Logger, sw storageWriter) (string, error) {
 		config := bitbucket.Config{
 			AccountName: bitbucketAccount,
 			Token:       bitbucketToken,
@@ -37,7 +37,7 @@ var bitbucketCmd = &cobra.Command{
 		}
 		exportPath := filepath.Join(storageBucketPath, exportName)
 
-		writer, err := storage.NewWriter(ctx, exportPath)
+		writer, err := sw.NewWriter(ctx, exportPath)
 		if err != nil {
 			return "", fmt.Errorf("failed to initialize writer: %w", err)
 		}

--- a/cmd/dumpb/contentful.go
+++ b/cmd/dumpb/contentful.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/foomo/dump-buckets/pkg/export"
+	storagepkg "github.com/foomo/dump-buckets/pkg/storage"
 	"github.com/spf13/cobra"
 )
 
@@ -30,13 +31,18 @@ var contentfulCmd = &cobra.Command{
 			return "", err
 		}
 
-		exportName := fmt.Sprintf("%s.gz", time.Now().Format(export.TimestampFormat))
+		exportName := fmt.Sprintf("%s.json.gz", time.Now().Format(export.TimestampFormat))
 		if backupName != "" {
 			exportName = fmt.Sprintf("%s/%s", backupName, exportName)
 		}
 		exportPath := filepath.Join(storageBucketPath, exportName)
 
-		writer, err := storage.NewWriter(ctx, exportPath)
+		writer, err := storage.NewWriter(
+			ctx,
+			exportPath,
+			storagepkg.WithContentType("application/json"),
+			storagepkg.WithContentEncoding("gzip"),
+		)
 		if err != nil {
 			return "", fmt.Errorf("failed to initialize writer: %w", err)
 		}

--- a/cmd/dumpb/contentful.go
+++ b/cmd/dumpb/contentful.go
@@ -42,6 +42,7 @@ var contentfulCmd = &cobra.Command{
 			exportPath,
 			storage.WithContentType("application/json"),
 			storage.WithContentEncoding("gzip"),
+			storage.WithMetadata("SpaceID", contentfulSpaceID),
 		)
 		if err != nil {
 			return "", fmt.Errorf("failed to initialize writer: %w", err)

--- a/cmd/dumpb/contentful.go
+++ b/cmd/dumpb/contentful.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/foomo/dump-buckets/pkg/export"
-	storagepkg "github.com/foomo/dump-buckets/pkg/storage"
+	"github.com/foomo/dump-buckets/pkg/storage"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +21,7 @@ var (
 var contentfulCmd = &cobra.Command{
 	Use:   "contentful",
 	Short: "Dumps contentful spaces in a specific bucket",
-	RunE: exportWrapper("Contentful", func(ctx context.Context, l *slog.Logger, storage storageWriter) (string, error) {
+	RunE: exportWrapper("Contentful", func(ctx context.Context, l *slog.Logger, sw storageWriter) (string, error) {
 		config := export.ContentfulExportConfig{
 			ManagementToken: contentfulManagementToken,
 			SpaceID:         contentfulSpaceID,
@@ -37,11 +37,11 @@ var contentfulCmd = &cobra.Command{
 		}
 		exportPath := filepath.Join(storageBucketPath, exportName)
 
-		writer, err := storage.NewWriter(
+		writer, err := sw.NewWriter(
 			ctx,
 			exportPath,
-			storagepkg.WithContentType("application/json"),
-			storagepkg.WithContentEncoding("gzip"),
+			storage.WithContentType("application/json"),
+			storage.WithContentEncoding("gzip"),
 		)
 		if err != nil {
 			return "", fmt.Errorf("failed to initialize writer: %w", err)

--- a/cmd/dumpb/dumpb.go
+++ b/cmd/dumpb/dumpb.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type exporterHandler func(ctx context.Context, l *slog.Logger, storage storageWriter) (outputPath string, err error)
+type exporterHandler func(ctx context.Context, l *slog.Logger, sw storageWriter) (outputPath string, err error)
 
 func exportWrapper(exporterName string, handler exporterHandler) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {

--- a/cmd/dumpb/execute.go
+++ b/cmd/dumpb/execute.go
@@ -33,7 +33,7 @@ var executeCmd = &cobra.Command{
 
 		wrapper := exportWrapper(
 			"execute",
-			func(ctx context.Context, l *slog.Logger, storage storageWriter) (string, error) {
+			func(ctx context.Context, l *slog.Logger, sw storageWriter) (string, error) {
 				cmdArgs := args[dashIndex:]
 
 				if len(cmdArgs) < 1 {
@@ -42,7 +42,7 @@ var executeCmd = &cobra.Command{
 
 				exportPath := filepath.Join(storageBucketPath, getExportName(time.Now()))
 
-				writer, err := storage.NewWriter(ctx, exportPath)
+				writer, err := sw.NewWriter(ctx, exportPath)
 				if err != nil {
 					return "", fmt.Errorf("failed to initialize writer: %w", err)
 				}

--- a/cmd/dumpb/github.go
+++ b/cmd/dumpb/github.go
@@ -22,7 +22,7 @@ var (
 var githubCmd = &cobra.Command{
 	Use:   "github",
 	Short: "Dumps github repositories in a destination bucket",
-	RunE: exportWrapper("GitHub", func(ctx context.Context, l *slog.Logger, storage storageWriter) (string, error) {
+	RunE: exportWrapper("GitHub", func(ctx context.Context, l *slog.Logger, sw storageWriter) (string, error) {
 		config := export.GitHubExportConfig{
 			Organization: githubOrganization,
 			Repository:   githubRepository,
@@ -39,7 +39,7 @@ var githubCmd = &cobra.Command{
 		}
 		exportPath := filepath.Join(storageBucketPath, exportName)
 
-		writer, err := storage.NewWriter(ctx, exportPath)
+		writer, err := sw.NewWriter(ctx, exportPath)
 		if err != nil {
 			return "", fmt.Errorf("failed to initialize writer: %w", err)
 		}

--- a/cmd/dumpb/mongo.go
+++ b/cmd/dumpb/mongo.go
@@ -23,7 +23,7 @@ var (
 var mongoCmd = &cobra.Command{
 	Use:   "mongo",
 	Short: "Dumps mongo into a bucket",
-	RunE: exportWrapper("GitHub", func(ctx context.Context, l *slog.Logger, storage storageWriter) (string, error) {
+	RunE: exportWrapper("GitHub", func(ctx context.Context, l *slog.Logger, sw storageWriter) (string, error) {
 		config := export.MongoExportConfig{
 			MongoURI:               mongoURI,
 			Username:               mongoUsername,
@@ -42,7 +42,7 @@ var mongoCmd = &cobra.Command{
 		exportPath := filepath.Join(storageBucketPath, exportName)
 		l = l.With(slog.String("path", exportPath))
 
-		writer, err := storage.NewWriter(ctx, exportPath)
+		writer, err := sw.NewWriter(ctx, exportPath)
 		if err != nil {
 			return "", fmt.Errorf("failed to initialize writer: %w", err)
 		}

--- a/cmd/dumpb/root.go
+++ b/cmd/dumpb/root.go
@@ -45,7 +45,7 @@ func Execute() {
 }
 
 type storageWriter interface {
-	NewWriter(ctx context.Context, path string) (writer io.WriteCloser, err error)
+	NewWriter(ctx context.Context, path string, opts ...storage.WriterOption) (writer io.WriteCloser, err error)
 }
 
 func configuredStorage(ctx context.Context) (storageWriter, error) {

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/foomo/dump-buckets/pkg/storage"
 )
 
 const (
@@ -16,7 +18,7 @@ const (
 )
 
 type Storage interface {
-	NewWriter(ctx context.Context, path string) (writer io.WriteCloser, err error)
+	NewWriter(ctx context.Context, path string, opts ...storage.WriterOption) (writer io.WriteCloser, err error)
 }
 
 // Tar takes a source and variable writers and walks 'source' writing each file

--- a/pkg/storage/options.go
+++ b/pkg/storage/options.go
@@ -1,0 +1,35 @@
+package storage
+
+// WriterAttrs holds optional attributes for storage writers
+type WriterAttrs struct {
+	ContentType     string
+	ContentEncoding string
+	Metadata        map[string]string
+}
+
+// WriterOption is a function that modifies WriterAttrs
+type WriterOption func(*WriterAttrs)
+
+// WithContentType sets the content type for the storage object
+func WithContentType(contentType string) WriterOption {
+	return func(attrs *WriterAttrs) {
+		attrs.ContentType = contentType
+	}
+}
+
+// WithContentEncoding sets the content encoding for the storage object
+func WithContentEncoding(encoding string) WriterOption {
+	return func(attrs *WriterAttrs) {
+		attrs.ContentEncoding = encoding
+	}
+}
+
+// WithMetadata sets custom metadata for the storage object
+func WithMetadata(key, value string) WriterOption {
+	return func(attrs *WriterAttrs) {
+		if attrs.Metadata == nil {
+			attrs.Metadata = make(map[string]string)
+		}
+		attrs.Metadata[key] = value
+	}
+}


### PR DESCRIPTION
This PR adds proper Content-Type and Content-Encoding metadata to Contentful exports for correct behavior with GCS signed URLs.

Changes:
- Introduced a variadic writer options pattern (WriterOption) for the storage layer
- Added WithContentType and WithContentEncoding helper functions
- Updated GCS storage to apply metadata (ContentType, ContentEncoding) to objects
- Changed Contentful export filename from .gz to .json.gz for clarity
- Set Content-Type: application/json and Content-Encoding: gzip for Contentful exports
- Refactored storageWriter parameter naming from 'storage' to 'sw' to avoid package shadowing

Files can now be downloaded via signed URLs with correct headers for proper browser handling.